### PR TITLE
Pass any extra command line arguments to plugin's __init__()

### DIFF
--- a/rc_exploit/main.py
+++ b/rc_exploit/main.py
@@ -14,7 +14,7 @@ def main():
     configure_logging(True)
 
     try:
-        plugin_inst = load_plugin(args.plugin)
+        plugin_inst = load_plugin(args.plugin, *args.remainder)
     except Exception, e:
         err_args = (args.plugin, e)
         logging.error('Failed to load plugin "%s". Exception: "%s"' % err_args)
@@ -80,4 +80,5 @@ def parse_args():
                                        ' module from paypal/hack.py)')
     parser.add_argument('--threads', type=int, default=50,
                         help='Number of threads/connections to use')
+    parser.add_argument('remainder', nargs=argparse.REMAINDER)
     return parser.parse_args()


### PR DESCRIPTION
Use `argparse.REMAINDER` to capture an array of any extra command line arguments and pass these to the `__init__()` of the plugin. If the plugin doesn't have an `__init__()` this works fine as long as no arguments are passed in.

The arguments are just passed in as strings into each argument of the `__init__()`. Default values of functions make simple optional arguments possible. Hypothetically, a complicated plugin could run argparse internally on the argument list for parsing. 

This should make tweaking requests easier and allow more powerful plugins.
